### PR TITLE
Initialize Go API skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Binaries
+bin/
+*.exe
+*.log
+
+# Build output
+*.out
+
+# IDE/editor configs
+.vscode/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+run:
+	go run ./cmd/api
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -155,3 +155,19 @@ Need help? Open a discussion or ping @maintainers.
 
 **mem0-go** is released under the [MIT License](LICENSE).
 
+
+## Development
+
+A minimal Go HTTP server is provided under `cmd/api`. Run it with:
+
+```bash
+make run
+```
+
+The server exposes a single `GET /healthz` endpoint that returns `{"status":"ok"}`.
+
+Run tests with:
+
+```bash
+make test
+```

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"mem0-go/internal/config"
+)
+
+func setupRoutes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ok"}`)
+	})
+	return mux
+}
+
+func main() {
+	cfg := config.Load()
+	addr := ":" + cfg.HTTPPort
+
+	log.Printf("starting server on %s", addr)
+	if err := http.ListenAndServe(addr, setupRoutes()); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthz(t *testing.T) {
+	server := httptest.NewServer(setupRoutes())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("failed to get healthz: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module mem0-go
+
+go 1.24.3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"os"
+)
+
+// Config holds application configuration values.
+type Config struct {
+	// HTTPPort is the port the API server listens on.
+	HTTPPort string
+}
+
+// Load reads configuration from environment variables or defaults.
+func Load() Config {
+	port := os.Getenv("APP_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	return Config{HTTPPort: port}
+}


### PR DESCRIPTION
## Summary
- start Go module `mem0-go`
- add HTTP server with `/healthz` route
- load basic config from env vars
- add make tasks and gitignore
- document minimal development instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c889da95883229fbd2c667f559f9a