### PR TITLE
Add basic CI workflow and make targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run Lint
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          make lint
+      - name: Run Tests
+        run: make test
+      - name: Dev
+        run: timeout 5s make dev || true
+      - name: Docker Build
+        run: make docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.24 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o /connect4 ./cmd/api
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=builder /connect4 /connect4
+EXPOSE 8080
+ENTRYPOINT ["/connect4"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
+.PHONY: run dev test lint docker-build ci
+
 run:
 	go run ./cmd/api
 
+dev: run
+
 test:
 	go test ./...
+
+lint:
+	golangci-lint run
+
+docker-build:
+	docker build -t connect4:latest .
+
+ci: lint test
+

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ mem0-go/
 
 ```bash
 # Run unit tests
-$ go test ./...
+$ make test
 
 # Lint & vet
-$ golangci-lint run
+$ make lint
 
 # Launch API only (uses local services already running via compose)
 $ make dev
@@ -161,13 +161,10 @@ Need help? Open a discussion or ping @maintainers.
 A minimal Go HTTP server is provided under `cmd/api`. Run it with:
 
 ```bash
-make run
+make dev
 ```
 
 The server exposes a single `GET /healthz` endpoint that returns `{"status":"ok"}`.
 
-Run tests with:
-
-```bash
-make test
-```
+Run tests with `make test` and lint with `make lint`. Build a Docker image
+using `make docker-build`.


### PR DESCRIPTION
## Summary
- add dockerfile for building the Go API
- expand Makefile with lint, test, dev, and docker-build targets
- update README with new Make commands
- run workflow on every PR

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685c8b68964c83228c911c693c239952