### PR TITLE
Add vector client

### DIFF
--- a/internal/vector/vector.go
+++ b/internal/vector/vector.go
@@ -1,0 +1,108 @@
+package vector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// Config holds Qdrant connection settings.
+type Config struct {
+	// Port is the HTTP port Qdrant listens on.
+	Port string
+}
+
+// LoadConfig reads settings from environment variables with fallbacks.
+func LoadConfig() Config {
+	port := os.Getenv("QDRANT_PORT")
+	if port == "" {
+		port = "6333"
+	}
+	return Config{Port: port}
+}
+
+// Client provides helpers for interacting with Qdrant.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Connect initializes a client using the given config.
+func Connect(_ context.Context, cfg Config) (*Client, error) {
+	return &Client{
+		baseURL:    fmt.Sprintf("http://localhost:%s", cfg.Port),
+		httpClient: &http.Client{},
+	}, nil
+}
+
+// Point represents a single vector with optional payload.
+type Point struct {
+	ID      string                 `json:"id"`
+	Vector  []float32              `json:"vector"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+}
+
+// Upsert writes points to the given collection.
+func (c *Client) Upsert(ctx context.Context, collection string, pts []Point) error {
+	body, err := json.Marshal(struct {
+		Points []Point `json:"points"`
+	}{pts})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		fmt.Sprintf("%s/collections/%s/points?wait=true", c.baseURL, collection), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("qdrant status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// QueryResult is a single vector search match.
+type QueryResult struct {
+	ID      string                 `json:"id"`
+	Score   float32                `json:"score"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+}
+
+// Query searches for similar vectors in a collection.
+func (c *Client) Query(ctx context.Context, collection string, vector []float32, limit int) ([]QueryResult, error) {
+	body, err := json.Marshal(struct {
+		Vector []float32 `json:"vector"`
+		Limit  int       `json:"limit"`
+	}{vector, limit})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/collections/%s/points/search", c.baseURL, collection), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("qdrant status %d", resp.StatusCode)
+	}
+	var out struct {
+		Result []QueryResult `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Result, nil
+}

--- a/internal/vector/vector_test.go
+++ b/internal/vector/vector_test.go
@@ -1,0 +1,44 @@
+package vector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpsertAndQuery(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/collections/test/points", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/collections/test/points/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		resp := struct {
+			Result []QueryResult `json:"result"`
+		}{Result: []QueryResult{{ID: "1", Score: 0.9}}}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, httpClient: srv.Client()}
+	if err := c.Upsert(context.Background(), "test", []Point{{ID: "1", Vector: []float32{1, 2}}}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	res, err := c.Query(context.Background(), "test", []float32{1, 2}, 1)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != "1" {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/vector` package with a small Qdrant client
- support `Upsert` and `Query` helpers
- rely on `QDRANT_PORT` to configure the pool

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c9e10679083228f2ef34d015d1b50