### PR TITLE
Add memory orchestration service

### DIFF
--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -1,0 +1,84 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"mem0-go/internal/db"
+	"mem0-go/internal/graph"
+	"mem0-go/internal/vector"
+)
+
+// Service orchestrates storage, search and relationships across
+// Postgres, Qdrant and Neo4j.
+// vectorStore defines the subset of vector.Client used by Service.
+type vectorStore interface {
+	Upsert(ctx context.Context, collection string, pts []vector.Point) error
+	Query(ctx context.Context, collection string, vector []float32, limit int) ([]vector.QueryResult, error)
+}
+
+type graphStore interface {
+	CreateNode(ctx context.Context, label string, props map[string]interface{}) (string, error)
+	CreateEdge(ctx context.Context, from, to, relType string, props map[string]interface{}) (string, error)
+	Neighbors(ctx context.Context, id, relType string) ([]graph.Node, error)
+}
+
+type Service struct {
+	repo   db.Repository
+	vector vectorStore
+	graph  graphStore
+}
+
+// NewService constructs a Service.
+func NewService(repo db.Repository, v vectorStore, g graphStore) *Service {
+	return &Service{repo: repo, vector: v, graph: g}
+}
+
+// StoreMemory persists the text and embedding then indexes it in Qdrant.
+func (s *Service) StoreMemory(ctx context.Context, userID int64, content string, emb []float32) (int64, error) {
+	id, err := s.repo.CreateMemory(ctx, userID, content)
+	if err != nil {
+		return 0, err
+	}
+	if err := s.repo.AddEmbedding(ctx, id, emb); err != nil {
+		return 0, err
+	}
+	if err := s.vector.Upsert(ctx, "memories", []vector.Point{{ID: fmt.Sprint(id), Vector: emb}}); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// MemoryResult represents a search match.
+type MemoryResult struct {
+	ID    int64
+	Score float32
+}
+
+// Search returns similar memories using Qdrant.
+func (s *Service) Search(ctx context.Context, emb []float32, limit int) ([]MemoryResult, error) {
+	res, err := s.vector.Query(ctx, "memories", emb, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]MemoryResult, 0, len(res))
+	for _, r := range res {
+		id, err := strconv.ParseInt(r.ID, 10, 64)
+		if err != nil {
+			continue
+		}
+		out = append(out, MemoryResult{ID: id, Score: r.Score})
+	}
+	return out, nil
+}
+
+// CreateEntity inserts a node into the graph.
+func (s *Service) CreateEntity(ctx context.Context, label string, props map[string]interface{}) (string, error) {
+	return s.graph.CreateNode(ctx, label, props)
+}
+
+// RelateEntities creates a relationship between two nodes.
+func (s *Service) RelateEntities(ctx context.Context, fromID, toID, relType string, props map[string]interface{}) (string, error) {
+	return s.graph.CreateEdge(ctx, fromID, toID, relType, props)
+}

--- a/internal/memory/service_test.go
+++ b/internal/memory/service_test.go
@@ -1,0 +1,183 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"mem0-go/internal/graph"
+	"mem0-go/internal/vector"
+)
+
+type stubRepo struct {
+	users      []string
+	memories   []string
+	embeddings [][]float32
+	createErr  error
+	embedErr   error
+}
+
+func (s *stubRepo) CreateUser(ctx context.Context, username string) (int64, error) {
+	s.users = append(s.users, username)
+	return int64(len(s.users)), nil
+}
+
+func (s *stubRepo) CreateMemory(ctx context.Context, userID int64, content string) (int64, error) {
+	if s.createErr != nil {
+		return 0, s.createErr
+	}
+	s.memories = append(s.memories, content)
+	return int64(len(s.memories)), nil
+}
+
+func (s *stubRepo) AddEmbedding(ctx context.Context, memoryID int64, vec []float32) error {
+	if s.embedErr != nil {
+		return s.embedErr
+	}
+	s.embeddings = append(s.embeddings, vec)
+	return nil
+}
+
+type stubVector struct {
+	upsertCalled bool
+	queryCalled  bool
+	upsertErr    error
+	queryErr     error
+}
+
+func (s *stubVector) Upsert(ctx context.Context, col string, pts []vector.Point) error {
+	s.upsertCalled = true
+	return s.upsertErr
+}
+
+func (s *stubVector) Query(ctx context.Context, col string, vec []float32, limit int) ([]vector.QueryResult, error) {
+	s.queryCalled = true
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+	return []vector.QueryResult{{ID: "1", Score: 0.9}}, nil
+}
+
+type stubGraph struct {
+	nodes   map[string]graph.Node
+	edges   []graph.Edge
+	next    int
+	nodeErr error
+	edgeErr error
+}
+
+func (g *stubGraph) CreateNode(_ context.Context, label string, props map[string]interface{}) (string, error) {
+	if g.nodeErr != nil {
+		return "", g.nodeErr
+	}
+	if g.nodes == nil {
+		g.nodes = make(map[string]graph.Node)
+	}
+	g.next++
+	id := fmt.Sprintf("n%d", g.next)
+	g.nodes[id] = graph.Node{ID: id, Label: label, Props: props}
+	return id, nil
+}
+
+func (g *stubGraph) CreateEdge(_ context.Context, from, to, relType string, props map[string]interface{}) (string, error) {
+	if g.edgeErr != nil {
+		return "", g.edgeErr
+	}
+	g.next++
+	id := fmt.Sprintf("e%d", g.next)
+	g.edges = append(g.edges, graph.Edge{ID: id, From: from, To: to, Type: relType, Props: props})
+	return id, nil
+}
+
+func (g *stubGraph) Neighbors(_ context.Context, id, relType string) ([]graph.Node, error) {
+	var out []graph.Node
+	for _, e := range g.edges {
+		if e.Type == relType && e.From == id {
+			if n, ok := g.nodes[e.To]; ok {
+				out = append(out, n)
+			}
+		}
+	}
+	return out, nil
+}
+
+func TestStoreAndSearch(t *testing.T) {
+	repo := &stubRepo{}
+	vec := &stubVector{}
+	g := &stubGraph{}
+	svc := NewService(repo, vec, g)
+
+	id, err := svc.StoreMemory(context.Background(), 1, "hello", []float32{1, 2})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if id != 1 {
+		t.Fatalf("unexpected id %d", id)
+	}
+	if !vec.upsertCalled {
+		t.Fatalf("upsert not called")
+	}
+
+	res, err := svc.Search(context.Background(), []float32{1, 2}, 1)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(res) != 1 || res[0].ID != 1 {
+		t.Fatalf("unexpected results: %+v", res)
+	}
+	if !vec.queryCalled {
+		t.Fatalf("query not called")
+	}
+}
+
+func TestRelateEntities(t *testing.T) {
+	repo := &stubRepo{}
+	vec := &stubVector{}
+	g := &stubGraph{}
+	svc := NewService(repo, vec, g)
+
+	n1, _ := svc.CreateEntity(context.Background(), "Person", nil)
+	n2, _ := svc.CreateEntity(context.Background(), "Person", nil)
+	id, err := svc.RelateEntities(context.Background(), n1, n2, "KNOWS", nil)
+	if err != nil {
+		t.Fatalf("relate: %v", err)
+	}
+	if id == "" {
+		t.Fatalf("empty edge id")
+	}
+	neigh, _ := g.Neighbors(context.Background(), n1, "KNOWS")
+	if len(neigh) != 1 || neigh[0].ID != n2 {
+		t.Fatalf("unexpected neighbors: %+v", neigh)
+	}
+}
+
+func TestStoreMemoryErrors(t *testing.T) {
+	repo := &stubRepo{createErr: fmt.Errorf("boom")}
+	vec := &stubVector{}
+	g := &stubGraph{}
+	if _, err := NewService(repo, vec, g).StoreMemory(context.Background(), 1, "x", nil); err == nil {
+		t.Fatalf("expected create error")
+	}
+
+	repo.createErr = nil
+	repo.embedErr = fmt.Errorf("bad")
+	if _, err := NewService(repo, vec, g).StoreMemory(context.Background(), 1, "x", nil); err == nil {
+		t.Fatalf("expected embed error")
+	}
+
+	repo.embedErr = nil
+	vec.upsertErr = fmt.Errorf("up")
+	if _, err := NewService(repo, vec, g).StoreMemory(context.Background(), 1, "x", nil); err == nil {
+		t.Fatalf("expected upsert error")
+	}
+}
+
+func TestSearchError(t *testing.T) {
+	repo := &stubRepo{}
+	vec := &stubVector{queryErr: fmt.Errorf("q")}
+	g := &stubGraph{}
+	svc := NewService(repo, vec, g)
+	if _, err := svc.Search(context.Background(), nil, 1); err == nil {
+		t.Fatalf("expected query error")
+	}
+}


### PR DESCRIPTION
## Summary
- add Service for storing memories, searching embeddings, and relating graph nodes
- implement in-memory tests to ensure >90% coverage

## Testing
- `go test ./...`
- `go test ./internal/memory -cover`


------
https://chatgpt.com/codex/tasks/task_e_685ca09e84748322869c55f8c7a065f4