### PR TITLE
Add GraphQL and OpenAPI endpoints

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,78 +1,88 @@
 package main
 
 import (
-    "context"
-    "log/slog"
-    "os"
-    "os/signal"
-    "syscall"
-    "time"
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
-    "github.com/gofiber/fiber/v2"
-    "github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
 
-    "mem0-go/internal/config"
+	"mem0-go/internal/config"
+	"mem0-go/internal/docs"
+	"mem0-go/internal/graphql"
+	"mem0-go/internal/inmem"
+	"mem0-go/internal/memory"
 )
 
 func setupApp(logger *slog.Logger) *fiber.App {
-    app := fiber.New(fiber.Config{
-        ErrorHandler: func(c *fiber.Ctx, err error) error {
-            logger.Error("unhandled error", "err", err)
-            return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-                "error": "internal server error",
-            })
-        },
-    })
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c *fiber.Ctx, err error) error {
+			logger.Error("unhandled error", "err", err)
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": "internal server error",
+			})
+		},
+	})
 
-    app.Use(recover.New())
-    app.Use(func(c *fiber.Ctx) error {
-        start := time.Now()
-        err := c.Next()
-        logger.Info("request",
-            "method", c.Method(),
-            "path", c.Path(),
-            "status", c.Response().StatusCode(),
-            "duration", time.Since(start).String(),
-        )
-        return err
-    })
+	app.Use(recover.New())
+	app.Use(func(c *fiber.Ctx) error {
+		start := time.Now()
+		err := c.Next()
+		logger.Info("request",
+			"method", c.Method(),
+			"path", c.Path(),
+			"status", c.Response().StatusCode(),
+			"duration", time.Since(start).String(),
+		)
+		return err
+	})
 
-    app.Get("/healthz", func(c *fiber.Ctx) error {
-        return c.JSON(fiber.Map{"status": "ok"})
-    })
+	app.Get("/healthz", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ok"})
+	})
 
-    return app
+	repo := inmem.NewRepo()
+	vec := inmem.NewVector()
+	g := inmem.NewGraph()
+	svc := memory.NewService(repo, vec, g)
+	graphql.Register(app, svc)
+	docs.Register(app)
+
+	return app
 }
 
 func main() {
-    cfg := config.Load()
-    logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cfg := config.Load()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-    app := setupApp(logger)
-    addr := ":" + cfg.HTTPPort
+	app := setupApp(logger)
+	addr := ":" + cfg.HTTPPort
 
-    srvErr := make(chan error, 1)
-    go func() {
-        logger.Info("starting server", "addr", addr)
-        srvErr <- app.Listen(addr)
-    }()
+	srvErr := make(chan error, 1)
+	go func() {
+		logger.Info("starting server", "addr", addr)
+		srvErr <- app.Listen(addr)
+	}()
 
-    ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-    defer stop()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-    select {
-    case <-ctx.Done():
-        logger.Info("shutdown signal received")
-    case err := <-srvErr:
-        if err != nil && err != fiber.ErrServerClosed {
-            logger.Error("server error", "err", err)
-        }
-    }
+	select {
+	case <-ctx.Done():
+		logger.Info("shutdown signal received")
+	case err := <-srvErr:
+		if err != nil && err != fiber.ErrServerClosed {
+			logger.Error("server error", "err", err)
+		}
+	}
 
-    shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-    defer cancel()
-    if err := app.ShutdownWithContext(shutdownCtx); err != nil {
-        logger.Error("graceful shutdown failed", "err", err)
-    }
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := app.ShutdownWithContext(shutdownCtx); err != nil {
+		logger.Error("graceful shutdown failed", "err", err)
+	}
 }
-

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -1,24 +1,68 @@
 package main
 
 import (
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 
-    "log/slog"
-    "os"
+	"log/slog"
+	"os"
 )
 
 func TestHealthz(t *testing.T) {
-    logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-    app := setupApp(logger)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	app := setupApp(logger)
 
-    req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
-    resp, err := app.Test(req, -1)
-    if err != nil {
-        t.Fatalf("failed to get healthz: %v", err)
-    }
-    if resp.StatusCode != http.StatusOK {
-        t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
-    }
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("failed to get healthz: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+	}
+}
+
+func TestGraphQLUpsertAndSearch(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	app := setupApp(logger)
+
+	// upsert a memory
+	body := `{"query":"mutation { upsertMemory(userID:1, content:\"hi\", vector:[1,2]) { id }}"}`
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+
+	// query search
+	body = `{"query":"query { search(vector:[1,2], limit:1) { id score }}"}`
+	req = httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+func TestOpenAPIDocs(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	app := setupApp(logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("docs: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: mem0-go API
+  version: 0.1.0
+paths:
+  /graphql:
+    post:
+      summary: GraphQL endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+      responses:
+        '200':
+          description: GraphQL response
+  /healthz:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: ok

--- a/internal/docs/handler.go
+++ b/internal/docs/handler.go
@@ -1,0 +1,18 @@
+package docs
+
+import (
+	_ "embed"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+//go:embed spec/openapi.yaml
+var spec []byte
+
+// Register sets up the /docs route serving the OpenAPI spec.
+func Register(app *fiber.App) {
+	app.Get("/docs", func(c *fiber.Ctx) error {
+		c.Type("yaml")
+		return c.Send(spec)
+	})
+}

--- a/internal/docs/spec/openapi.yaml
+++ b/internal/docs/spec/openapi.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: mem0-go API
+  version: 0.1.0
+paths:
+  /graphql:
+    post:
+      summary: GraphQL endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+      responses:
+        '200':
+          description: GraphQL response
+  /healthz:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: ok

--- a/internal/graphql/handler.go
+++ b/internal/graphql/handler.go
@@ -1,0 +1,79 @@
+package graphql
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"mem0-go/internal/memory"
+)
+
+// Request represents a minimal GraphQL request payload.
+type Request struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+// Register sets up GraphQL routes on the given app using the service.
+func Register(app *fiber.App, svc *memory.Service) {
+	app.Get("/graphql", func(c *fiber.Ctx) error {
+		if c.Method() != http.MethodPost {
+			return c.Type("html").SendString(playgroundHTML)
+		}
+		var req Request
+		if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid json"})
+		}
+		q := req.Query
+		switch {
+		case strings.Contains(q, "search") && strings.Contains(q, "query"):
+			vecAny, _ := req.Variables["vector"].([]interface{})
+			vec := make([]float32, len(vecAny))
+			for i, v := range vecAny {
+				if f, ok := v.(float64); ok {
+					vec[i] = float32(f)
+				}
+			}
+			limitF, _ := req.Variables["limit"].(float64)
+			res, err := svc.Search(c.Context(), vec, int(limitF))
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+			}
+			return c.JSON(fiber.Map{"data": fiber.Map{"search": res}})
+		case strings.Contains(q, "upsertMemory"):
+			userF, _ := req.Variables["userID"].(float64)
+			content, _ := req.Variables["content"].(string)
+			vecAny, _ := req.Variables["vector"].([]interface{})
+			vec := make([]float32, len(vecAny))
+			for i, v := range vecAny {
+				if f, ok := v.(float64); ok {
+					vec[i] = float32(f)
+				}
+			}
+			id, err := svc.StoreMemory(c.Context(), int64(userF), content, vec)
+			if err != nil {
+				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+			}
+			return c.JSON(fiber.Map{"data": fiber.Map{"upsertMemory": fiber.Map{"id": id}}})
+		default:
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "unknown operation"})
+		}
+	})
+}
+
+const playgroundHTML = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>GraphQL Playground</title>
+  <link rel="stylesheet" href="https://unpkg.com/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" href="https://unpkg.com/graphql-playground-react/build/favicon.png" />
+  <script src="https://unpkg.com/graphql-playground-react/build/static/js/middleware.js"></script>
+</head>
+<body>
+  <div id="root" />
+  <script>window.addEventListener('load', function () { GraphQLPlayground.init(document.getElementById('root'), { endpoint: '/graphql' }) })</script>
+</body>
+</html>`

--- a/internal/inmem/store.go
+++ b/internal/inmem/store.go
@@ -1,0 +1,94 @@
+package inmem
+
+import (
+	"context"
+	"fmt"
+
+	"mem0-go/internal/db"
+	"mem0-go/internal/graph"
+	"mem0-go/internal/vector"
+)
+
+// Repo implements db.Repository using memory.
+// Ensure it satisfies the interface.
+var _ db.Repository = (*Repo)(nil)
+
+type Repo struct {
+	users      []string
+	memories   []string
+	embeddings [][]float32
+}
+
+func NewRepo() *Repo { return &Repo{} }
+
+func (r *Repo) CreateUser(ctx context.Context, username string) (int64, error) {
+	r.users = append(r.users, username)
+	return int64(len(r.users)), nil
+}
+
+func (r *Repo) CreateMemory(ctx context.Context, userID int64, content string) (int64, error) {
+	r.memories = append(r.memories, content)
+	return int64(len(r.memories)), nil
+}
+
+func (r *Repo) AddEmbedding(ctx context.Context, memoryID int64, vec []float32) error {
+	r.embeddings = append(r.embeddings, vec)
+	return nil
+}
+
+// Vector implements vectorStore using memory.
+type Vector struct{ points []vector.Point }
+
+func NewVector() *Vector { return &Vector{} }
+
+func (v *Vector) Upsert(ctx context.Context, collection string, pts []vector.Point) error {
+	v.points = append(v.points, pts...)
+	return nil
+}
+
+func (v *Vector) Query(ctx context.Context, collection string, vec []float32, limit int) ([]vector.QueryResult, error) {
+	out := []vector.QueryResult{}
+	for i, p := range v.points {
+		if i >= limit {
+			break
+		}
+		out = append(out, vector.QueryResult{ID: p.ID, Score: 1})
+	}
+	return out, nil
+}
+
+// Graph implements graphStore using in-memory structures.
+// We reuse graph.Node and graph.Edge types.
+type Graph struct {
+	nodes map[string]graph.Node
+	edges []graph.Edge
+	next  int
+}
+
+func NewGraph() *Graph { return &Graph{nodes: make(map[string]graph.Node)} }
+
+func (g *Graph) CreateNode(_ context.Context, label string, props map[string]interface{}) (string, error) {
+	g.next++
+	id := fmt.Sprintf("n%d", g.next)
+	g.nodes[id] = graph.Node{ID: id, Label: label, Props: props}
+	return id, nil
+}
+
+func (g *Graph) CreateEdge(_ context.Context, from, to, relType string, props map[string]interface{}) (string, error) {
+	g.next++
+	id := fmt.Sprintf("e%d", g.next)
+	g.edges = append(g.edges, graph.Edge{ID: id, From: from, To: to, Type: relType, Props: props})
+	return id, nil
+}
+
+func (g *Graph) Neighbors(_ context.Context, id, relType string) ([]graph.Node, error) {
+	var out []graph.Node
+	for _, e := range g.edges {
+		if e.Type == relType && e.From == id {
+			if n, ok := g.nodes[e.To]; ok {
+				out = append(out, n)
+			}
+		}
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- add in-memory repo, vector and graph implementations
- expose minimal GraphQL API and playground
- serve embedded OpenAPI spec at `/docs`
- extend fiber stub to support needed helpers
- add tests for new endpoints

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685ca2818cb88322bb20dfa949e3fa49