### PR TITLE
Add basic worker binary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ QDRANT_PORT=6333
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4jtest
 
+# Redis
+REDIS_ADDR=localhost:6379
+
 # Optional embedding key
 MEM0_EMBEDDING_KEY=

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All configuration is environment‑driven. Key variables:
 | `QDRANT_PORT`        | `6333`      | Qdrant HTTP port                  |
 | `NEO4J_USER`         | `neo4j`     | Neo4j user                        |
 | `NEO4J_PASSWORD`     | `neo4jtest` | Neo4j password                    |
+| `REDIS_ADDR`         | `localhost:6379` | Redis endpoint for workers |
 | `MEM0_EMBEDDING_KEY` | *‑empty‑*   | OpenAI / LM Studio key (optional) |
 
 Create additional overrides in `docker/.env.local` which is `.gitignore`d.
@@ -124,6 +125,8 @@ $ make lint
 
 # Launch API only (uses local services already running via compose)
 $ make dev
+# Run workers
+$ go run ./cmd/worker
 ```
 
 Front‑end hot‑reload:

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	workers "github.com/jrallison/go-workers"
+)
+
+var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+func embeddingJob(msg *workers.Msg) {
+	logger.Info("embedding job", "args", msg.Args())
+}
+
+func linkJob(msg *workers.Msg) {
+	logger.Info("link job", "args", msg.Args())
+}
+
+func main() {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+
+	workers.Configure(map[string]string{
+		"server":  addr,
+		"process": "1",
+		"pool":    "1",
+	})
+
+	workers.Process("embeddings", embeddingJob, 1)
+	workers.Process("links", linkJob, 1)
+
+	go workers.Run()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+	workers.Quit()
+}

--- a/cmd/worker/main_test.go
+++ b/cmd/worker/main_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+
+	workers "github.com/jrallison/go-workers"
+)
+
+func TestEmbeddingJob(t *testing.T) {
+	msg := workers.NewMsg([]interface{}{"hi"})
+	embeddingJob(msg)
+}
+
+func TestLinkJob(t *testing.T) {
+	msg := workers.NewMsg([]interface{}{"a", "b"})
+	linkJob(msg)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,11 @@ go 1.24.3
 require (
 	github.com/gofiber/fiber/v2 v2.52.0
 	github.com/jackc/pgx/v5 v5.5.0
+	github.com/jrallison/go-workers v0.0.0
 )
 
 replace github.com/gofiber/fiber/v2 => ./internal/fiber
 
 replace github.com/jackc/pgx/v5 => ./internal/pgx
+
+replace github.com/jrallison/go-workers => ./internal/workers

--- a/internal/workers/go.mod
+++ b/internal/workers/go.mod
@@ -1,0 +1,3 @@
+module github.com/jrallison/go-workers
+
+go 1.20

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -1,0 +1,21 @@
+package workers
+
+// Msg mimics the message passed to job handlers.
+type Msg struct{ args []interface{} }
+
+// Args returns job arguments.
+func (m *Msg) Args() []interface{} { return m.args }
+
+// NewMsg constructs a Msg from args.
+func NewMsg(args []interface{}) *Msg { return &Msg{args: args} }
+
+// JobFunc is a handler for a job.
+type JobFunc func(*Msg)
+
+func Configure(map[string]string) {}
+
+func Process(queue string, fn JobFunc, concurrency int) {}
+
+func Run() {}
+
+func Quit() {}


### PR DESCRIPTION
## Summary
- add stub go-workers implementation
- create `cmd/worker` to process embedding and link jobs
- expose `REDIS_ADDR` configuration
- document worker usage

## Testing
- `go build ./cmd/worker`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685ca7b73298832295308db2e6966744