### PR TITLE
Add React UI with Vite and Zustand

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ $ cp .env.example .env
 # 3. Fire up the whole stack 🐳
 $ docker compose -f docker/compose.yaml up -d --build
 
-# 4. Explore
+# 4. In another shell start the UI dev server
+$ cd ui && pnpm i && pnpm dev
+
+# 5. Explore
 UI          → http://localhost:3000  (Vite dev, hot‑reload)
 GraphQL UI  → http://localhost:8080/graphql
 Qdrant UI   → http://localhost:6333

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -8,11 +8,13 @@ import (
 
 func TestCreateAndQuery(t *testing.T) {
 	// stub dialer to avoid real network
-	dialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		c1, c2 := net.Pipe()
-		go c1.Close()
-		return c2, nil
-	}
+        dialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+                c1, c2 := net.Pipe()
+                go func() {
+                        _ = c1.Close()
+                }()
+                return c2, nil
+        }
 
 	cfg := LoadConfig()
 	g, err := Connect(context.Background(), cfg)

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>mem0-go</title>
+  </head>
+  <body class="min-h-screen bg-background font-sans antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.4.7",
+    "class-variance-authority": "^0.7.0",
+    "tailwind-merge": "^1.14.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@types/react-router-dom": "^5.3.3",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.8"
+  }
+}

--- a/ui/postcss.config.js
+++ b/ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,18 @@
+import { Route, Routes, Link } from 'react-router-dom';
+import { Home } from './pages/Home';
+import { About } from './pages/About';
+
+export default function App() {
+  return (
+    <div className="container mx-auto p-4">
+      <nav className="mb-4 flex gap-4">
+        <Link to="/" className="font-bold">Home</Link>
+        <Link to="/about">About</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+      </Routes>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 255 255 255;
+    --foreground: 17 24 39;
+    --primary: 59 130 246;
+    --primary-foreground: 255 255 255;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/ui/src/pages/About.tsx
+++ b/ui/src/pages/About.tsx
@@ -1,0 +1,8 @@
+export function About() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">About</h1>
+      <p>This is a sample React app powered by Vite and shadcn/ui.</p>
+    </div>
+  );
+}

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -1,0 +1,14 @@
+import { useCounterStore } from '../store';
+
+export function Home() {
+  const count = useCounterStore((s) => s.count);
+  const increment = useCounterStore((s) => s.increment);
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Home</h1>
+      <button className="px-4 py-2 bg-primary text-primary-foreground rounded" onClick={increment}>
+        Count is {count}
+      </button>
+    </div>
+  );
+}

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface CounterState {
+  count: number;
+  increment: () => void;
+}
+
+export const useCounterStore = create<CounterState>((set) => ({
+  count: 0,
+  increment: () => set((state) => ({ count: state.count + 1 })),
+}));

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  darkMode: ['class'],
+  content: ['index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'rgb(var(--background))',
+        foreground: 'rgb(var(--foreground))',
+        primary: 'rgb(var(--primary))',
+        'primary-foreground': 'rgb(var(--primary-foreground))',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- bootstrap Vite/React frontend under `ui`
- configure Tailwind and shadcn compatible global styles
- set up router and Zustand store
- document running the dev server
- fix lint issue in graph test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685cab3fd55c8322875f471fefe4c390