### PR TITLE
Add Apollo client for UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ REDIS_ADDR=localhost:6379
 
 # Optional embedding key
 MEM0_EMBEDDING_KEY=
+
+# Frontend
+VITE_API_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ All configuration is environment‑driven. Key variables:
 | `NEO4J_PASSWORD`     | `neo4jtest` | Neo4j password                    |
 | `REDIS_ADDR`         | `localhost:6379` | Redis endpoint for workers |
 | `MEM0_EMBEDDING_KEY` | *‑empty‑*   | OpenAI / LM Studio key (optional) |
+| `VITE_API_URL`       | `http://localhost:8080` | Base URL for the API |
 
 Create additional overrides in `docker/.env.local` which is `.gitignore`d.
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -34,6 +34,8 @@ services:
       - ../ui:/usr/share/nginx/html:ro
     ports:
       - "3000:80"
+    environment:
+      VITE_API_URL: http://api:8080
     depends_on:
       api:
         condition: service_healthy

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,9 @@
     "react-router-dom": "^6.22.3",
     "zustand": "^4.4.7",
     "class-variance-authority": "^0.7.0",
-    "tailwind-merge": "^1.14.0"
+    "tailwind-merge": "^1.14.0",
+    "@apollo/client": "^3.9.10",
+    "graphql": "^16.8.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/ui/src/graphqlClient.ts
+++ b/ui/src/graphqlClient.ts
@@ -1,0 +1,8 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+const client = new ApolloClient({
+  uri: `${import.meta.env.VITE_API_URL}/graphql`,
+  cache: new InMemoryCache(),
+});
+
+export default client;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ApolloProvider } from '@apollo/client';
+import client from './graphqlClient';
 import App from './App';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ApolloProvider client={client}>
+        <App />
+      </ApolloProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- expose `VITE_API_URL` in `.env.example`
- pass API URL to the `ui` service via docker compose
- include Apollo Client deps
- create a GraphQL client and provider
- document new env var in README

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_685cac49d4688322923b1dcce8daf08d