### PR TITLE
Add memory search UI with Playwright tests

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -64,3 +64,15 @@ paths:
       responses:
         '200':
           description: search results
+  /api/v1/memories/{id}:
+    get:
+      summary: Get memory
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: memory record

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -11,6 +11,15 @@ type Repository interface {
 	CreateUser(ctx context.Context, username string) (int64, error)
 	CreateMemory(ctx context.Context, userID int64, content string) (int64, error)
 	AddEmbedding(ctx context.Context, memoryID int64, vector []float32) error
+	GetMemory(ctx context.Context, id int64) (Memory, error)
+}
+
+// Memory represents a stored memory record.
+type Memory struct {
+	ID        int64
+	UserID    int64
+	Content   string
+	CreatedAt string
 }
 
 // PgxRepository implements Repository with a pgx pool.
@@ -39,4 +48,13 @@ func (r *PgxRepository) CreateMemory(ctx context.Context, userID int64, content 
 func (r *PgxRepository) AddEmbedding(ctx context.Context, memoryID int64, vector []float32) error {
 	_, err := r.pool.Exec(ctx, "INSERT INTO embeddings (memory_id, vector) VALUES ($1,$2)", memoryID, vector)
 	return err
+}
+
+func (r *PgxRepository) GetMemory(ctx context.Context, id int64) (Memory, error) {
+	row := r.pool.QueryRow(ctx, "SELECT id, user_id, content, created_at FROM memories WHERE id=$1", id)
+	var m Memory
+	if err := row.Scan(&m.ID, &m.UserID, &m.Content, &m.CreatedAt); err != nil {
+		return Memory{}, err
+	}
+	return m, nil
 }

--- a/internal/docs/spec/openapi.yaml
+++ b/internal/docs/spec/openapi.yaml
@@ -64,3 +64,15 @@ paths:
       responses:
         '200':
           description: search results
+  /api/v1/memories/{id}:
+    get:
+      summary: Get memory
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: memory record

--- a/internal/inmem/store.go
+++ b/internal/inmem/store.go
@@ -36,6 +36,13 @@ func (r *Repo) AddEmbedding(ctx context.Context, memoryID int64, vec []float32) 
 	return nil
 }
 
+func (r *Repo) GetMemory(ctx context.Context, id int64) (db.Memory, error) {
+	if int(id) <= 0 || int(id) > len(r.memories) {
+		return db.Memory{}, fmt.Errorf("not found")
+	}
+	return db.Memory{ID: id, UserID: 1, Content: r.memories[id-1]}, nil
+}
+
 // Vector implements vectorStore using memory.
 type Vector struct{ points []vector.Point }
 

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -35,6 +35,11 @@ func NewService(repo db.Repository, v vectorStore, g graphStore) *Service {
 	return &Service{repo: repo, vector: v, graph: g}
 }
 
+// GetMemory retrieves a memory record by ID.
+func (s *Service) GetMemory(ctx context.Context, id int64) (db.Memory, error) {
+	return s.repo.GetMemory(ctx, id)
+}
+
 // StoreMemory persists the text and embedding then indexes it in Qdrant.
 func (s *Service) StoreMemory(ctx context.Context, userID int64, content string, emb []float32) (int64, error) {
 	id, err := s.repo.CreateMemory(ctx, userID, content)

--- a/internal/rest/handler.go
+++ b/internal/rest/handler.go
@@ -2,6 +2,8 @@ package rest
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -65,5 +67,31 @@ func Register(app *fiber.App, svc *memory.Service) {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 		}
 		return c.JSON(fiber.Map{"results": res})
+	})
+
+	// @Summary Get memory
+	// @Description Retrieve memory by ID
+	// @Tags memories
+	// @Produce json
+	// @Param id path int true "Memory ID"
+	// @Success 200 {object} db.Memory
+	// @Failure 400 {object} map[string]string
+	// @Failure 500 {object} map[string]string
+	// @Router /api/v1/memories/{id} [get]
+	app.Get("/api/v1/memories/:id", func(c *fiber.Ctx) error {
+		parts := strings.Split(c.Path(), "/")
+		if len(parts) == 0 {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid id"})
+		}
+		idStr := parts[len(parts)-1]
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid id"})
+		}
+		m, err := svc.GetMemory(c.Context(), id)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.JSON(m)
 	})
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -27,6 +28,7 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.2.2",
-    "vite": "^5.2.8"
+    "vite": "^5.2.8",
+    "playwright": "^1.42.1"
   }
 }

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    cwd: __dirname,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});

--- a/ui/src/components/MemoryDetails.tsx
+++ b/ui/src/components/MemoryDetails.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+interface Memory {
+  id: number;
+  userID: number;
+  content: string;
+  createdAt: string;
+}
+
+export function MemoryDetails({ id }: { id: number }) {
+  const [memory, setMemory] = useState<Memory | null>(null);
+
+  useEffect(() => {
+    fetch(`${import.meta.env.VITE_API_URL}/api/v1/memories/${id}`)
+      .then((r) => r.json())
+      .then((d) => setMemory(d));
+  }, [id]);
+
+  if (!memory) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <p className="mb-2">{memory.content}</p>
+      <p className="text-sm text-gray-500">User {memory.userID}</p>
+    </div>
+  );
+}

--- a/ui/src/components/SearchMemories.tsx
+++ b/ui/src/components/SearchMemories.tsx
@@ -1,0 +1,73 @@
+import { gql, useLazyQuery } from '@apollo/client';
+import { useState } from 'react';
+import { MemoryDetails } from './MemoryDetails';
+
+const SEARCH = gql`
+  query Search($vector: [Float!], $limit: Int) {
+    search(vector: $vector, limit: $limit) {
+      id
+      score
+    }
+  }
+`;
+
+interface Result {
+  id: number;
+  score: number;
+}
+
+export function SearchMemories() {
+  const [vectorInput, setVectorInput] = useState('');
+  const [limit, setLimit] = useState(5);
+  const [selected, setSelected] = useState<Result | null>(null);
+  const [runSearch, { data, loading }] = useLazyQuery<{ search: Result[] }>(SEARCH);
+
+  const results = data?.search ?? [];
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const vector = vectorInput
+      .split(',')
+      .map((v) => parseFloat(v.trim()))
+      .filter((v) => !Number.isNaN(v));
+    runSearch({ variables: { vector, limit } });
+  };
+
+  return (
+    <div className="flex gap-4">
+      <div className="flex-1">
+        <form onSubmit={onSubmit} className="mb-4 flex gap-2">
+          <input
+            className="border px-2 py-1 flex-1"
+            value={vectorInput}
+            onChange={(e) => setVectorInput(e.target.value)}
+            placeholder="Vector e.g. 0.1,0.2"
+          />
+          <input
+            type="number"
+            className="border px-2 py-1 w-16"
+            value={limit}
+            onChange={(e) => setLimit(parseInt(e.target.value, 10))}
+          />
+          <button className="px-4 py-1 bg-primary text-primary-foreground rounded">Search</button>
+        </form>
+        <ul>
+          {loading && <li>Loading...</li>}
+          {results.map((r) => (
+            <li key={r.id}>
+              <button onClick={() => setSelected(r)} className="underline text-blue-600">
+                Memory {r.id} (score {r.score.toFixed(2)})
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      {selected && (
+        <div className="w-64 p-4 border-l">
+          <h2 className="font-bold mb-2">Memory {selected.id}</h2>
+          <MemoryDetails id={selected.id} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { useCounterStore } from '../store';
+import { SearchMemories } from '../components/SearchMemories';
 
 export function Home() {
   const count = useCounterStore((s) => s.count);
@@ -9,6 +10,9 @@ export function Home() {
       <button className="px-4 py-2 bg-primary text-primary-foreground rounded" onClick={increment}>
         Count is {count}
       </button>
+      <div className="mt-6">
+        <SearchMemories />
+      </div>
     </div>
   );
 }

--- a/ui/tests/search.spec.ts
+++ b/ui/tests/search.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home shows search form', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByPlaceholder('Vector e.g. 0.1,0.2')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- create search UI for memories
- show memory details in sidebar
- expose memory retrieval REST endpoint
- document new endpoint in OpenAPI spec
- smoke test UI with Playwright

## Testing
- `make lint`
- `make test`
- `npx playwright test` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685cad82a97483228d0f3978b7866239